### PR TITLE
FIX: Remove deprecated SCSS imports

### DIFF
--- a/scss/lib/discourse-nav.scss
+++ b/scss/lib/discourse-nav.scss
@@ -1,5 +1,3 @@
-@import "common/foundation/variables";
-@import "theme_variables";
 @import "lib/mixins";
 
 $mobile-avatar-image-size: 1.8em;


### PR DESCRIPTION
The `theme_variables` import is now removed from core, and the SCSS compiler will throw an error when it is present. (The other import is injected by core on all SCSS files, so it's not needed.) 